### PR TITLE
Add permalinking

### DIFF
--- a/static/js/view.js
+++ b/static/js/view.js
@@ -175,9 +175,25 @@ const renderPrev = () => {
 	togglePageNavButtonsVisibility();
 };
 
+const getPermalink = () => {
+	const url = new URL(window.location);
+	return url.searchParams.get("pepid");
+};
+
 const main = () => {
 	const searchBox = document.querySelector("#searchBox");
 	searchBox.oninput = triggerSearch;
+
+	const permalink = getPermalink();
+	if (permalink) {
+		searchBox.value = `PEP${permalink}`;
+
+		const searchSection = document.querySelector("#search");
+		searchSection.style.display = "none";
+
+		const resultsCount = document.querySelector("#resultsCount");
+		resultsCount.style.display = "none";
+	}
 };
 
 main();


### PR DESCRIPTION
We can now permalink to a peptide by using query params on searchable pages.
Just add a query param mentioning the PEP ID like so `?pepid=1234`.
We disable the search box, search hints and the results count.